### PR TITLE
added Hydra#abort! which also releases easy handles and clears caches

### DIFF
--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -47,6 +47,12 @@ module Typhoeus
       @queued_requests.clear
     end
 
+    # in addition to abort, also releases running requests and clears caches
+    def abort!
+      abort
+      reset_easy_handles_and_caches
+    end
+
     def clear_cache_callbacks
       @cache_setter = nil
       @cache_getter = nil
@@ -103,11 +109,7 @@ module Typhoeus
 
       @multi.perform
     ensure
-      @multi.reset_easy_handles{|easy| release_easy_object(easy)}
-      @memoized_requests = {}
-      @retrieved_from_cache = {}
-      @completed_requests = {}
-      @running_requests = 0
+      reset_easy_handles_and_caches
     end
 
     def disable_memoization
@@ -286,5 +288,14 @@ module Typhoeus
                    :request             => request)
     end
     private :response_from_easy
+
+    def reset_easy_handles_and_caches
+      @multi.reset_easy_handles {|easy| release_easy_object(easy) }
+      @memoized_requests = {}
+      @retrieved_from_cache = {}
+      @completed_requests = {}
+      @running_requests = 0
+    end
+    private :reset_easy_handles_and_caches
   end
 end

--- a/spec/typhoeus/hydra_spec.rb
+++ b/spec/typhoeus/hydra_spec.rb
@@ -115,6 +115,25 @@ describe Typhoeus::Hydra do
     completed.should < 10
   end
 
+  it "abort! resets easy handles and caches" do
+    hydra  = Typhoeus::Hydra.new(:max_concurrency => 1)
+    2.times do
+      hydra.queue Typhoeus::Request.new("http://localhost:3000/foo")
+    end
+
+    hydra.instance_variable_get("@queued_requests").size.should == 1
+    hydra.instance_variable_get("@memoized_requests").size.should == 1
+    hydra.instance_variable_get("@running_requests").should == 1
+    hydra.instance_variable_get("@multi").easy_handles.size == 1
+
+    hydra.abort!
+
+    hydra.instance_variable_get("@queued_requests").size.should == 0
+    hydra.instance_variable_get("@memoized_requests").size.should == 0
+    hydra.instance_variable_get("@running_requests").should == 0
+    hydra.instance_variable_get("@multi").easy_handles.size == 0
+  end
+
   it "has a cache_setter proc" do
     hydra = Typhoeus::Hydra.new
     hydra.cache_setter do |request|


### PR DESCRIPTION
Added abort method, which should be used in the middleware instead of Hydra#abort to avoid memoize bug in case run was never called for some reason.
