### PR TITLE
Retry connect timeouts regardless of request method

### DIFF
--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -231,8 +231,7 @@ module Typhoeus
     end
 
     def retry_request?(request, response)
-      :get == request.method &&
-      (retry_codes.include?(response.code) || (retry_connect_timeouts? && response.connect_timed_out?)) &&
+      ((:get == request.method && retry_codes.include?(response.code)) || (retry_connect_timeouts? && response.connect_timed_out?)) &&
       !request.requeued? &&
       request.retry?
     end

--- a/spec/typhoeus/hydra_spec.rb
+++ b/spec/typhoeus/hydra_spec.rb
@@ -452,32 +452,56 @@ describe Typhoeus::Hydra do
   end
 
   describe "retry_request?" do
-    before(:all) do
-      @hydra    = Typhoeus::Hydra.new
-      @request  = Typhoeus::Request.new("/foo", :method => :get)
-      @response = Typhoeus::Response.new
-    end
+    let(:hydra)    { Typhoeus::Hydra.new }
+    let(:request)  { Typhoeus::Request.new("/foo", :method => method) }
+    let(:response) { Typhoeus::Response.new }
 
-    context "when retry_connect_timeouts is disabled" do
-      it "returns false on connect timeout" do
-        @response.stub(:connect_timed_out?).and_return(true)
-        @hydra.retry_request?(@request, @response).should be_false
+    context "for non-GET request" do
+      let(:method) { :put }
+
+      context "when retry_connect_timeouts is disabled" do
+        it "returns false on connect timeout" do
+          response.stub(:connect_timed_out?).and_return(true)
+          hydra.retry_request?(request, response).should be_false
+        end
+      end
+
+      context "when retry_connect_timeouts is enabled" do
+        before do
+          hydra.retry_connect_timeouts = true
+        end
+
+        it "returns true on connect timeout" do
+          response.stub(:connect_timed_out?).and_return(true)
+          hydra.retry_request?(request, response).should be_true
+        end
       end
     end
 
-    context "when retry_connect_timeouts is enabled" do
-      before(:all) do
-        @hydra.retry_connect_timeouts = true
+    context "for GET request" do
+      let(:method) { :get }
+
+      context "when retry_connect_timeouts is disabled" do
+        it "returns false on connect timeout" do
+          response.stub(:connect_timed_out?).and_return(true)
+          hydra.retry_request?(request, response).should be_false
+        end
       end
 
-      it "returns true on connect timeout" do
-        @response.stub(:connect_timed_out?).and_return(true)
-        @hydra.retry_request?(@request, @response).should be_true
-      end
+      context "when retry_connect_timeouts is enabled" do
+        before do
+          hydra.retry_connect_timeouts = true
+        end
 
-      it "returns false on normal timeout" do
-        @response.stub(:connect_timed_out?).and_return(false)
-        @hydra.retry_request?(@request, @response).should be_false
+        it "returns true on connect timeout" do
+          response.stub(:connect_timed_out?).and_return(true)
+          hydra.retry_request?(request, response).should be_true
+        end
+
+        it "returns false on normal timeout" do
+          response.stub(:connect_timed_out?).and_return(false)
+          hydra.retry_request?(request, response).should be_false
+        end
       end
     end
   end


### PR DESCRIPTION
This allows to retry non-GET calls on connection timeout. I assume it is always safe because we never reach the server in that case. Please have a look.
Thanks!
