### PR TITLE
Perf and memory improvements

### DIFF
--- a/lib/typhoeus/normalized_header_hash.rb
+++ b/lib/typhoeus/normalized_header_hash.rb
@@ -52,7 +52,7 @@ module Typhoeus
 
   private
     def convert_key(key)
-      key.to_s.split(/_|-/).map { |segment| segment.capitalize }.join("-")
+      key.to_s.tr('_'.freeze,'-'.freeze).split('-'.freeze).map! { |segment| segment.capitalize }.join('-'.freeze)
     end
   end
 end


### PR DESCRIPTION
I found some performance hotspot in the convert_key method, that is called very often during normal request.

The first commit replaces the split regex with tr and split by string, which improves performance by factor 1.3. The second improvement is adding .freeze to some of the strings to save string allocations (on sandbox it saved around 2k during profiling run, on a live test run with feedy I got a few hundred saved allocations).

    Calculating -------------------------------------
               no freeze    20.880k i/100ms
                  freeze    20.553k i/100ms
               tr_freeze    27.033k i/100ms
            tr_no_freeze    25.549k i/100ms
    -------------------------------------------------
               no freeze    243.812k (± 3.3%) i/s -      1.232M
                  freeze    243.688k (± 2.2%) i/s -      1.233M
               tr_freeze    319.384k (± 2.7%) i/s -      1.622M
            tr_no_freeze    311.743k (± 2.1%) i/s -      1.558M

    Comparison:
               tr_freeze:   319384.5 i/s
            tr_no_freeze:   311743.4 i/s - 1.02x slower
               no freeze:   243811.8 i/s - 1.31x slower
                  freeze:   243687.6 i/s - 1.31x slower

Benchmark script

    require 'benchmark/ips'

    KEY = :'HALLO_WELT-Wie_gEHTs'

    def convert_key(key)
      key.to_s.split(/_|-/).map { |segment| segment.capitalize }.join("-")
    end

    def convert_key_freeze(key)
      key.to_s.split(/_|-/).map { |segment| segment.capitalize.freeze }.join("-".freeze)
    end

    def convert_key_tr_freeze(key)
      key.to_s.tr('-'.freeze,'_'.freeze).split('_'.freeze).map { |segment| segment.capitalize.freeze }.join("-".freeze)
    end

    def convert_key_tr_no_freeze(key)
      key.to_s.tr('-','_').split('_').map { |segment| segment.capitalize }.join("-")
    end


    Benchmark.ips do |x|
      x.report('no freeze') { convert_key(KEY) }
      x.report('freeze') { convert_key_freeze(KEY) }
      x.report('tr_freeze') { convert_key_tr_freeze(KEY) }
      x.report('tr_no_freeze') { convert_key_tr_no_freeze(KEY) }
      x.compare!
    end
