### PR TITLE
Allow selection of DNS resolution protocol

### DIFF
--- a/lib/typhoeus/easy.rb
+++ b/lib/typhoeus/easy.rb
@@ -32,6 +32,7 @@ module Typhoeus
       :CURLOPT_PROXYUSERPWD   => 10000 + 6,
       :CURLOPT_PROXYTYPE      => 101,
       :CURLOPT_PROXYAUTH      => 111,
+      :CURLOPT_IPRESOLVE      => 113,
       :CURLOPT_VERIFYPEER     => 64,
       :CURLOPT_VERIFYHOST    => 81,
       :CURLOPT_NOBODY         => 44,
@@ -44,6 +45,7 @@ module Typhoeus
       :CURLOPT_CAINFO         => 10065,
       :CURLOPT_CAPATH         => 10097,
     }
+
     INFO_VALUES = {
       :CURLINFO_RESPONSE_CODE      => 2097154,
       :CURLINFO_TOTAL_TIME         => 3145731,
@@ -72,6 +74,11 @@ module Typhoeus
       :CURLPROXY_SOCKS4A      => 6,
     }
 
+    IPRESOLVE_PROTOCOLS = {
+      :CURL_IPRESOLVE_WHATEVER => 0,
+      :CURL_IPRESOLVE_V4       => 1,
+      :CURL_IPRESOLVE_V6       => 2,
+    }
 
     def initialize
       @method = :get
@@ -97,6 +104,10 @@ module Typhoeus
     def proxy=(proxy)
       set_option(OPTION_VALUES[:CURLOPT_PROXY], proxy[:server])
       set_option(OPTION_VALUES[:CURLOPT_PROXYTYPE], proxy[:type]) if proxy[:type]
+    end
+
+    def ipresolve=(protocol)
+      set_option(OPTION_VALUES[:CURLOPT_IPRESOLVE], IPRESOLVE_PROTOCOLS[protocol])
     end
 
     def proxy_auth=(authinfo)

--- a/lib/typhoeus/hydra.rb
+++ b/lib/typhoeus/hydra.rb
@@ -188,6 +188,7 @@ module Typhoeus
       easy.interface       = request.interface if request.interface
       easy.follow_location = request.follow_location if request.follow_location
       easy.max_redirects = request.max_redirects if request.max_redirects
+      easy.ipresolve        = request.ipresolve if request.ipresolve
       easy.disable_ssl_peer_verification if request.disable_ssl_peer_verification
       easy.disable_ssl_host_verification if request.disable_ssl_host_verification
       easy.ssl_cert         = request.ssl_cert

--- a/lib/typhoeus/request.rb
+++ b/lib/typhoeus/request.rb
@@ -11,7 +11,7 @@ module Typhoeus
                   :ssl_cert, :ssl_cert_type, :ssl_key, :ssl_key_type,
                   :ssl_key_password, :ssl_cacert, :ssl_capath, :verbose,
                   :username, :password, :auth_method, :user_agent,
-                  :proxy_auth_method, :proxy_type, :attempt_retry, :performed
+                  :proxy_auth_method, :proxy_type, :ipresolve, :attempt_retry, :performed
 
     alias_method :performed?, :performed
 
@@ -32,6 +32,7 @@ module Typhoeus
     # ** +:follow_location
     # ** +:max_redirects
     # ** +:proxy
+    # ** +:ipresolve : protocol to use for hostname resolution
     # ** +:disable_ssl_peer_verification
     # ** +:disable_ssl_host_verification
     # ** +:ssl_cert
@@ -61,6 +62,7 @@ module Typhoeus
       @max_redirects    = options[:max_redirects]
       @proxy            = options[:proxy]
       @proxy_type       = options[:proxy_type]
+      @ipresolve        = options[:ipresolve]
       @proxy_username   = options[:proxy_username]
       @proxy_password   = options[:proxy_password]
       @proxy_auth_method = options[:proxy_auth_method]


### PR DESCRIPTION
This allows us to select which protocol `libcurl` uses to resolv hostnames.